### PR TITLE
fixed disable wifi on android devices

### DIFF
--- a/src/wifi/android.py
+++ b/src/wifi/android.py
@@ -21,7 +21,7 @@ class AndroidNetwork:
         if active_wifi_interface.stdout == '':
             src.utils.die('[!] Could not determine active android Wi-Fi interface')
 
-        self.INTERFACE = active_wifi_interface
+        self.INTERFACE = active_wifi_interface.stdout.strip()
 
     def storeAlwaysScanState(self):
         """Stores Initial Wi-Fi 'always-scanning' state, so it can be restored on exit"""


### PR DESCRIPTION
At [this line](https://github.com/chickendrop89/OneShot-Extended/blob/e9e58d724054e2d7ed227ac130b2b2f3f87d7166/src/wifi/android.py#L44) 
command is 
ip link set CompletedProcess(args='getprop wifi.interface', returncode=0, stdout='wlan0\n', stderr='') down && ip link set CompletedProcess(args='getprop wifi.interface', returncode=0, stdout='wlan0\n', stderr='') up

just fixed it