### PR TITLE
fix AttributeError and implement null pin attack

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This is an improved version of the original OneShot
 
 # Features
  - [Pixie Dust attack](https://forums.kali.org/showthread.php?24286-WPS-Pixie-Dust-Attack-Offline-WPS-Attack)
+ - Null Pin attack
  - Offline WPS PIN generating algorithm
  - [Online WPS bruteforce](https://sviehb.files.wordpress.com/2011/12/viehboeck_wps.pdf)
  - Wi-Fi scanner with highlighting based on iw;
@@ -25,7 +26,7 @@ Required arguments:
 
 Optional arguments:
   -b, --bssid BSSID            : BSSID of the target AP
-  -p, --pin PIN                : Use the specified pin (arbitrary string or 4/8 digit pin)
+  -p, --pin PIN                : Use the specified pin (arbitrary string or 4/8 digit pin). Enter a blank pin (e.g. '') for a Null Pin attack
   -K, --pixie-dust             : Run Pixie Dust attack
   -F, --pixie-force            : Run Pixiewps with --force option (bruteforce full range)
   -B, --bruteforce             : Run online bruteforce attack

--- a/src/args.py
+++ b/src/args.py
@@ -36,7 +36,7 @@ def parseArgs():
     parser.add_argument(
         '-p', '--pin',
         type=str,
-        help='Use the specified pin (arbitrary string or 4/8 digit pin)'
+        help='Use the specified pin (arbitrary string or 4/8 digit pin). Enter a blank pin (e.g. '') for a Null Pin attack'
     )
     parser.add_argument(
         '-K', '--pixie-dust',

--- a/src/wps/connection.py
+++ b/src/wps/connection.py
@@ -104,7 +104,8 @@ class Initialize:
         pixiewps_dir = src.utils.PIXIEWPS_DIR
         generator    = src.wps.generator.WPSpin()
         collector    = src.wifi.collector.WiFiCollector()
-
+        
+        # Allow empty string ('') as valid pin (e.g., for null pin attack)
         if pin is None:
             if pixiemode:
                 try:

--- a/src/wps/connection.py
+++ b/src/wps/connection.py
@@ -105,7 +105,7 @@ class Initialize:
         generator    = src.wps.generator.WPSpin()
         collector    = src.wifi.collector.WiFiCollector()
 
-        if not pin:
+        if pin is None:
             if pixiemode:
                 try:
                     filename = f'''{pixiewps_dir}{bssid.replace(':', '').upper()}.run'''

--- a/src/wps/generator.py
+++ b/src/wps/generator.py
@@ -256,7 +256,7 @@ class WPSpin:
 
     @staticmethod
     def _pinASUS(bssid: str):
-        b = [int(i, 16) for i in bssid.string.split(':')]
+        b = [int(i, 16) for i in str(bssid).split(':')]
         pin = ''
         for i in range(7):
             pin += str((b[i % 6] + b[5]) % (10 - (i + b[1] + b[2] + b[3] + b[4] + b[5]) % 7))
@@ -265,7 +265,7 @@ class WPSpin:
 
     @staticmethod
     def _pinAirocon(bssid: str):
-        b = [int(i, 16) for i in bssid.string.split(':')]
+        b = [int(i, 16) for i in str(bssid).split(':')]
         pin = ((b[0] + b[1]) % 10)\
         + (((b[5] + b[0]) % 10) * 10)\
         + (((b[4] + b[5]) % 10) * 100)\


### PR DESCRIPTION
fixed a bug where the script crashes with ASUS (and Airocon? untested) APs; allowed blank pin argument for null pin attack (tested on Deco M9 Plus AP)
perhaps null pin attack feature line is missing its source but all what i could find is that its from reaver-wps-fork-t6x