### PR TITLE
args: escape the apostrophes in blank pin example

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -36,7 +36,7 @@ def parseArgs():
     parser.add_argument(
         '-p', '--pin',
         type=str,
-        help='Use the specified pin (arbitrary string or 4/8 digit pin). Enter a blank pin (e.g. '') for a Null Pin attack'
+        help='Use the specified pin (arbitrary string or 4/8 digit pin). Enter a blank pin (e.g. \'\') for a Null Pin attack'
     )
     parser.add_argument(
         '-K', '--pixie-dust',


### PR DESCRIPTION
pardon, a little oversight